### PR TITLE
bindShared has been renamed to singleton

### DIFF
--- a/src/Pabloroman/Opengraph/Providers/OpengraphServiceProvider.php
+++ b/src/Pabloroman/Opengraph/Providers/OpengraphServiceProvider.php
@@ -38,7 +38,7 @@ class OpengraphServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('Opengraph', function ($app)
+		$this->app->singleton('Opengraph', function ($app)
 		{
 			return new Opengraph(new Embed, $app['cache.store']);
 		});


### PR DESCRIPTION
Fix for Laravel 5.2
